### PR TITLE
feat: Add Card with Image(small ver.) with hover effect resolve #9

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -21,7 +21,7 @@ const CardComponentPage = () => {
         place={"돈카춘 노원점"}
         link={"/"}
         rating={"4.5"}
-        numberOfReviews={30}
+        reviewCount={30}
         images={images}
         info={info}
       />
@@ -29,7 +29,7 @@ const CardComponentPage = () => {
         place={"dghsajhgldhljghjdhdjdghjhlds"}
         link={"/"}
         rating={"4.1"}
-        numberOfReviews={300}
+        reviewCount={300}
         images={images}
         info={info}
       />

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -3,6 +3,7 @@ import CardWithImage, {
   CardWithDislike,
   CardWithLike,
 } from "@/components/common/Cards/CardWithImage";
+import { CardWithImageSmall } from "@/components/common/Cards/CardWithImageSmall";
 import { Size } from "@/model";
 import React from "react";
 
@@ -24,10 +25,14 @@ const CardComponentPage = () => {
         images={images}
         info={info}
       />
-      <div className="flex flex-row gap-x-5">
-        <CardWithLike size={Size.small} />
-        <CardWithDislike size={Size.large} />
-      </div>
+      <CardWithImageSmall
+        place={"dghsajhgldhljghjdhdjdghjhlds"}
+        link={"/"}
+        rating={"4.1"}
+        numberOfReviews={300}
+        images={images}
+        info={info}
+      />
     </div>
   );
 };

--- a/components/common/Cards/CardWithImage.tsx
+++ b/components/common/Cards/CardWithImage.tsx
@@ -16,7 +16,7 @@ export const CardWithImage: React.FC<CardInfoProps> = ({
   const router = useRouter();
 
   return (
-    <Card className="flex flex-col items-center w-[335px] max-h-[372px] py-[24px]">
+    <Card className="flex flex-col items-center w-[335px] max-h-[372px] py-[24px] rounded-xl ">
       <div className="flex flex-col w-[295px] h-[139px]">
         <div className="flex flex-row gap-x-[8px]">
           <CardHeader>
@@ -59,7 +59,7 @@ export const CardWithImage: React.FC<CardInfoProps> = ({
       </div>
       <hr className="w-[295px] mt-[24px]" />
       <CardContent className="flex flex-col w-[295px] h-[161px] gap-y-[8px] my-[20px]">
-        {info.map((item, index) => (
+        {info?.map((item, index) => (
           <div
             key={index}
             className="flex flex-row justify-between w-[295px] h-[21px] gap-x-[16px] text-[14px]"

--- a/components/common/Cards/CardWithImageSmall.tsx
+++ b/components/common/Cards/CardWithImageSmall.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
+import { CardInfoProps } from "@/model";
+
+export const CardWithImageSmall: React.FC<CardInfoProps> = ({
+  place,
+  link,
+  rating,
+  numberOfReviews,
+  images,
+}) => {
+  return (
+    <Card className="ml-10 flex flex-col items-start justify-center w-[160px] h-[157px] cursor-pointer">
+      <CardContent className="flex flex-col w-full gap-y-[8px]">
+        <div className="relative w-[160px] h-[110px] overflow-hidden rounded-[12px] items-center justify-center">
+          <Image
+            src={images[0]}
+            alt="like"
+            width={160}
+            height={110}
+            className="absolute inset-0 w-full h-full transition-transform duration-300 hover:scale-110"
+            priority
+          />
+        </div>
+        <div className="flex flex-col w-full h-[39px] items-start">
+          <span className="font-semibold text-[14px] whitespace-nowrap overflow-hidden text-ellipsis inline-block max-w-full">
+            {place}
+          </span>
+
+          <div className="flex flex-row w-[71px] h-[18px gap-x-[2px] items-center">
+            <Image
+              src="/png/naver.png"
+              alt="naver"
+              width={12}
+              height={12}
+              priority
+            />
+            <span className="text-[12px] max-w-[24px] h-[18px] items-center text-black">
+              {rating}
+            </span>
+            <span className="text-[12px] max-w-[31px] h-[18px] items-center text-[#B5B9C6]">
+              ({numberOfReviews})
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,10 +8,7 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow-xl",
-      className
-    )}
+    className={cn("border bg-card text-card-foreground shadow-xl", className)}
     {...props}
   />
 ));

--- a/model/index.ts
+++ b/model/index.ts
@@ -11,7 +11,7 @@ export interface CardInfoProps {
   place: string;
   link: string;
   rating: string;
-  numberOfReviews: number;
+  reviewCount: number;
   images: string[];
   info?: { label: string; value: string }[];
 }

--- a/model/index.ts
+++ b/model/index.ts
@@ -13,7 +13,7 @@ export interface CardInfoProps {
   rating: string;
   numberOfReviews: number;
   images: string[];
-  info: { label: string; value: string }[];
+  info?: { label: string; value: string }[];
 }
 
 export interface ImgProps {


### PR DESCRIPTION
**이미지를 포함하는 카드 컴포넌트 (small ver.) 를 추가했습니다.**

- mouse hover 시에 이미지 내부적으로 1.1배 확대하도록 설정
- 한 줄을 넘는 장소 이름을 가질 경우 말줄임 처리

* 테스트를 위해 test/page.tsx에 의도적으로 장소 이름을 길게 설정했습니다! 


컴포넌트 네이밍이 너무 어렵네요 ㅠ ㅠ 회초리 부탁드립니다 ㅎㅎ