### PR TITLE
Fix error with drag action and edit labels - resolve#39

### DIFF
--- a/app/edit-course/_components/DragAndDropArea.tsx
+++ b/app/edit-course/_components/DragAndDropArea.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { DragDropContext, DropResult, Draggable } from "react-beautiful-dnd";
 import Image from "next/image";
 import CardWithCourse from "@/components/common/Cards/CardWithCourse";
@@ -21,10 +21,6 @@ export type ColumnsType = {
     id: "course";
     list: Record<OrderType, ValueType[]>;
   };
-};
-
-type DragAndDropProps = {
-  initialColumns: ColumnsType;
 };
 
 const updateColumnsOnDelete = (
@@ -67,10 +63,42 @@ const reorder = (
   return result;
 };
 
-const DragAndDropArea: React.FC<DragAndDropProps> = ({ initialColumns }) => {
-  const [columns, setColumns] = useState(initialColumns);
+const generateUniqueTitles = (columns: ColumnsType): ColumnsType => {
+  const updatedColumns = { ...columns };
+  Object.keys(updatedColumns.course.list).forEach((category) => {
+    updatedColumns.course.list[category as OrderType].forEach((item, index) => {
+      if (updatedColumns.course.list[category as OrderType].length > 1) {
+        item.title = `${item.title.split(" ")[0]} ${index + 1}차`;
+      } else {
+        item.title = item.title.split(" ")[0];
+      }
+    });
+  });
+  return updatedColumns;
+};
+
+const DragAndDropArea: React.FC = () => {
+  // 사용자가 설정한 데이터라고 가정
+  const initialColumns: ColumnsType = {
+    course: {
+      id: "course",
+      list: {
+        food: [
+          { globalIndex: 0, title: "음식", type: "food", icon: "🍔" },
+          { globalIndex: 2, title: "음식", type: "food", icon: "🍔" },
+        ],
+        dessert: [
+          { globalIndex: 1, title: "디저트", type: "dessert", icon: "🥨" },
+        ],
+        beer: [],
+        play: [],
+      },
+    },
+  };
+  const updatedInitialColumns = generateUniqueTitles(initialColumns);
+  const [columns, setColumns] = useState(updatedInitialColumns);
   const [itemCount, setItemCount] = useState(
-    Object.values(initialColumns.course.list).flat().length
+    Object.values(updatedInitialColumns.course.list).flat().length
   );
 
   const allItems = useMemo(() => {
@@ -107,9 +135,13 @@ const DragAndDropArea: React.FC<DragAndDropProps> = ({ initialColumns }) => {
   };
 
   const handleItemDelete = (globalIndexToDelete: number) => {
-    setColumns((prevColumns) =>
-      updateColumnsOnDelete(prevColumns, globalIndexToDelete)
-    );
+    setColumns((prevColumns) => {
+      const updatedColumns = updateColumnsOnDelete(
+        prevColumns,
+        globalIndexToDelete
+      );
+      return generateUniqueTitles(updatedColumns);
+    });
     setItemCount(itemCount - 1);
   };
 
@@ -124,16 +156,19 @@ const DragAndDropArea: React.FC<DragAndDropProps> = ({ initialColumns }) => {
       icon: icon.icon,
     };
 
-    setColumns((prevColumns) => ({
-      ...prevColumns,
-      course: {
-        ...prevColumns.course,
-        list: {
-          ...prevColumns.course.list,
-          [type]: [...prevColumns.course.list[type], newItem],
+    setColumns((prevColumns) => {
+      const updatedColumns = {
+        ...prevColumns,
+        course: {
+          ...prevColumns.course,
+          list: {
+            ...prevColumns.course.list,
+            [type]: [...prevColumns.course.list[type], newItem],
+          },
         },
-      },
-    }));
+      };
+      return generateUniqueTitles(updatedColumns);
+    });
     setItemCount(itemCount + 1);
   };
 

--- a/app/edit-course/_components/DragAndDropArea.tsx
+++ b/app/edit-course/_components/DragAndDropArea.tsx
@@ -27,26 +27,36 @@ const updateColumnsOnDelete = (
   prevColumns: ColumnsType,
   globalIndexToDelete: number
 ): ColumnsType => {
-  const updatedList: Record<OrderType, ValueType[]> = {
+  const updatedList: ValueType[] = [];
+
+  Object.values(prevColumns.course.list)
+    .flat()
+    .forEach((item) => {
+      if (item.globalIndex !== globalIndexToDelete) {
+        updatedList.push(item);
+      }
+    });
+
+  const newList: Record<OrderType, ValueType[]> = {
     food: [],
     dessert: [],
     beer: [],
     play: [],
   };
 
-  Object.values(prevColumns.course.list)
-    .flat()
-    .forEach((item) => {
-      if (item.globalIndex !== globalIndexToDelete) {
-        updatedList[item.type].push(item);
-      }
-    });
+  updatedList.forEach((item, index) => {
+    const newIndex =
+      item.globalIndex > globalIndexToDelete
+        ? item.globalIndex - 1
+        : item.globalIndex;
+    newList[item.type].push({ ...item, globalIndex: newIndex });
+  });
 
   return {
     ...prevColumns,
     course: {
       ...prevColumns.course,
-      list: updatedList,
+      list: newList,
     },
   };
 };
@@ -85,10 +95,10 @@ const DragAndDropArea: React.FC = () => {
       list: {
         food: [
           { globalIndex: 0, title: "음식", type: "food", icon: "🍔" },
-          { globalIndex: 2, title: "음식", type: "food", icon: "🍔" },
+          { globalIndex: 1, title: "음식", type: "food", icon: "🍔" },
         ],
         dessert: [
-          { globalIndex: 1, title: "디저트", type: "dessert", icon: "🥨" },
+          { globalIndex: 2, title: "디저트", type: "dessert", icon: "🥨" },
         ],
         beer: [],
         play: [],
@@ -100,6 +110,10 @@ const DragAndDropArea: React.FC = () => {
   const [itemCount, setItemCount] = useState(
     Object.values(updatedInitialColumns.course.list).flat().length
   );
+
+  useEffect(() => {
+    setColumns(updatedInitialColumns);
+  }, []);
 
   const allItems = useMemo(() => {
     return Object.values(columns.course.list)
@@ -184,7 +198,7 @@ const DragAndDropArea: React.FC = () => {
             >
               {allItems.map((item: ValueType, index: number) => (
                 <Draggable
-                  key={item.globalIndex}
+                  key={index}
                   draggableId={`item-${item.type}-${item.globalIndex}`}
                   index={index}
                 >

--- a/app/edit-course/page.tsx
+++ b/app/edit-course/page.tsx
@@ -1,26 +1,8 @@
 import React from "react";
-import DragAndDropArea, { ColumnsType } from "./_components/DragAndDropArea";
-
-// 사용자가 설정한 데이터라고 가정
-const initialColumns: ColumnsType = {
-  course: {
-    id: "course",
-    list: {
-      food: [
-        { globalIndex: 0, title: "음식", type: "food", icon: "🍔" },
-        { globalIndex: 2, title: "음식", type: "food", icon: "🍔" },
-      ],
-      dessert: [
-        { globalIndex: 1, title: "디저트", type: "dessert", icon: "🥨" },
-      ],
-      beer: [],
-      play: [],
-    },
-  },
-};
+import DragAndDropArea from "./_components/DragAndDropArea";
 
 const EditCoursePage = () => {
-  return <DragAndDropArea initialColumns={initialColumns} />;
+  return <DragAndDropArea />;
 };
 
 export default EditCoursePage;


### PR DESCRIPTION
**1. 항목 추가 혹은 삭제 시에 같은 카테고리의 아이템이 여러 개가 되는 순간에 "N차" 라벨이 부착될 수 있도록 수정, 삭제 시에 "N차" 라벨을 즉각적으로 제거할 수 있도록 else문을 추가**
- 해당 함수는 generateUniqueTitles()입니다.

**2. 항목 추가 혹은 삭제 시에 기존 카테고리 배열의 순서를 따르는 에러 해결**
- 예를 들어, 디저트-음식 1차-음식 2차에서 음식 1차가 삭제되는 경우, 카테고리 순서(음식-디저트-술-놀거리)에 기반해 음식(2차였던 것)-디저트와 같이 수정되어버리는 이슈가 있었습니다. 이때 재정렬된 컬럼들을 반환하는 updateList에서 globalIndex를 그대로 사용하는 것이 아니라, 제거된 아이템들의 위치에 기반해 기존의 순서를 카테고리와 관계없이 유지할 수 있도록 처리했습니다. 

다음과 같이 처리해보았습니다.
(1) prevColumns.course.list에 접근해 삭제할 아이템들은 제외하고 새로 리스트를 생성해 updateList를 구성한다.
(2) 새로운 빈 리스트인 newList를 생성한다.
(3) 기존의 globalIndex를 유지하되, globalIndexToDelete(삭제할 아이템)보다 큰 인덱스를 가진 경우에는 index-1을 넣어 newList에서 재배열한다.


**번외)** 
- 페이지 초기 진입 시에 initialColumns(추후 사용자 데이터)에 대한 초기 세팅이 되지 않는 이슈, DragDropArea 내부에 initialColumns를 배치하도록 수정하고 -> N차 라벨링을 부착한 후 -> columns에 반영하도록 수정한 후 useEffect 훅을 이용해 명시적으로 세팅하여 해결
- _useMemo & dnd library 관련 warning에 대해_ -library의 개발이 멈췄기 때문에 patch하는 방식으로 해결 필요, 해당 PR에서 제외합니다.