### PR TITLE
Add list areas and components to show voting results resolve #53

### DIFF
--- a/app/vote-edit/_components/EditOptionArea.tsx
+++ b/app/vote-edit/_components/EditOptionArea.tsx
@@ -1,25 +1,11 @@
 "use client";
 import { CategoryChip } from "@/app/add-course/_components/CategoryChip";
-import { ColumnsType } from "@/app/edit-course/_components/DragAndDropArea";
 import { CardWithSelectedOption } from "@/components/common/Cards/CardWithSelectedOption";
 import { flattenColumns } from "@/lib/utils";
-import { useRouter } from "next/navigation";
+import { VoteAreaProps } from "@/model";
 import { useState } from "react";
 
-interface EditOptionAreaProps {
-  initialColumns: ColumnsType;
-  placesInfo: Array<{
-    place: string;
-    link: string;
-    rating: string;
-    reviewCount: number;
-    images: string[];
-  }>;
-}
-const EditOptionArea = ({
-  initialColumns,
-  placesInfo,
-}: EditOptionAreaProps) => {
+const EditOptionArea = ({ initialColumns, placesInfo }: VoteAreaProps) => {
   const [selectedChip, setSelectedChip] = useState<number | null>(null);
   const [selectedCard, setSelectedCard] = useState<number | null>(null);
 

--- a/app/vote-edit/page.tsx
+++ b/app/vote-edit/page.tsx
@@ -24,6 +24,11 @@ const placesInfo = [
     rating: "4.01",
     reviewCount: 433,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "스타벅스 강남점",
@@ -31,6 +36,11 @@ const placesInfo = [
     rating: "4.5",
     reviewCount: 1200,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "맥도날드 홍대점",
@@ -38,6 +48,11 @@ const placesInfo = [
     rating: "3.8",
     reviewCount: 530,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "빕스 여의도점",
@@ -45,6 +60,11 @@ const placesInfo = [
     rating: "4.2",
     reviewCount: 870,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "이디야 커피 신촌점",
@@ -52,6 +72,11 @@ const placesInfo = [
     rating: "4.0",
     reviewCount: 300,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
 ];
 

--- a/app/vote-finish/_components/ResultArea.tsx
+++ b/app/vote-finish/_components/ResultArea.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { CategoryChip } from "@/app/add-course/_components/CategoryChip";
+import { ColumnsType } from "@/app/edit-course/_components/DragAndDropArea";
+import CardWithImage from "@/components/common/Cards/CardWithImage";
+import Image from "next/image";
+import { flattenColumns } from "@/lib/utils";
+import { useState } from "react";
+
+interface EditOptionAreaProps {
+  initialColumns: ColumnsType;
+  placesInfo: Array<{
+    place: string;
+    link: string;
+    rating: string;
+    reviewCount: number;
+    images: string[];
+  }>;
+}
+const ResultArea = ({ initialColumns, placesInfo }: EditOptionAreaProps) => {
+  const [selectedChip, setSelectedChip] = useState<number | null>(null);
+  const [expandedCards, setExpandedCards] = useState<number[]>([]);
+
+  const handleChipClick = (index: number) => {
+    setSelectedChip(index === selectedChip ? null : index);
+  };
+
+  const handleArrowClick = (index: number) => {
+    setExpandedCards((prev) =>
+      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+    );
+  };
+
+  return (
+    <div className="flex flex-col w-[335px] h-[631px] mx-[20px] gap-y-[26px]">
+      <div className="flex flex-row w-[252px] h-[37px] gap-x-[8px]">
+        {flattenColumns(initialColumns).map((item) => (
+          <CategoryChip
+            key={item.globalIndex}
+            title={item.title}
+            selected={selectedChip === item.globalIndex}
+            onClick={() => handleChipClick(item.globalIndex)}
+          />
+        ))}
+      </div>
+      <div className="flex flex-col gap-y-[12px]">
+        {placesInfo.map((placeInfo, index) => (
+          <div key={index}>
+            <div
+              className={`flex flex-row rounded-[12px] ${
+                index === 0 ? "bg-[#FFF7F2]" : "bg-[#F9FAFB]"
+              } w-[335px] h-[64px] items-center justify-between p-[20px]`}
+            >
+              <div className="flex flex-row items-center justify-start gap-x-[8px]">
+                <span className="w-[20px] h-[20px] items-center bg-black text-[12px] font-semibold text-white flex justify-center rounded-[64px]">
+                  {index + 1}
+                </span>
+                <span>{placeInfo.place}</span>{" "}
+                <span className="flex w-[21px] items-center h-[21px] text-[14px] opacity-[0.5] text-[#363A3C]">
+                  6명
+                </span>
+              </div>
+              <button onClick={() => handleArrowClick(index)}>
+                <Image
+                  src={"/png/ic_arrow_down_16.png"}
+                  width={16}
+                  height={16}
+                  alt="arrow"
+                  className="mr-[4px]"
+                />
+              </button>
+            </div>
+            {expandedCards.includes(index) && (
+              <CardWithImage
+                place={placeInfo.place}
+                link={placeInfo.link}
+                rating={placeInfo.rating}
+                reviewCount={placeInfo.reviewCount}
+                images={placeInfo.images || []}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ResultArea;

--- a/app/vote-finish/_components/ResultArea.tsx
+++ b/app/vote-finish/_components/ResultArea.tsx
@@ -1,22 +1,12 @@
 "use client";
 import { CategoryChip } from "@/app/add-course/_components/CategoryChip";
-import { ColumnsType } from "@/app/edit-course/_components/DragAndDropArea";
 import CardWithImage from "@/components/common/Cards/CardWithImage";
 import Image from "next/image";
 import { flattenColumns } from "@/lib/utils";
 import { useState } from "react";
+import { VoteAreaProps } from "@/model";
 
-interface EditOptionAreaProps {
-  initialColumns: ColumnsType;
-  placesInfo: Array<{
-    place: string;
-    link: string;
-    rating: string;
-    reviewCount: number;
-    images: string[];
-  }>;
-}
-const ResultArea = ({ initialColumns, placesInfo }: EditOptionAreaProps) => {
+const ResultArea = ({ initialColumns, placesInfo }: VoteAreaProps) => {
   const [selectedChip, setSelectedChip] = useState<number | null>(null);
   const [expandedCards, setExpandedCards] = useState<number[]>([]);
 
@@ -71,6 +61,7 @@ const ResultArea = ({ initialColumns, placesInfo }: EditOptionAreaProps) => {
             </div>
             {expandedCards.includes(index) && (
               <CardWithImage
+                info={placeInfo.info}
                 place={placeInfo.place}
                 link={placeInfo.link}
                 rating={placeInfo.rating}

--- a/app/vote-finish/page.tsx
+++ b/app/vote-finish/page.tsx
@@ -24,6 +24,11 @@ const placesInfo = [
     rating: "4.01",
     reviewCount: 433,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "스타벅스 강남점",
@@ -31,6 +36,11 @@ const placesInfo = [
     rating: "4.5",
     reviewCount: 1200,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "맥도날드 홍대점",
@@ -38,6 +48,11 @@ const placesInfo = [
     rating: "3.8",
     reviewCount: 530,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "빕스 여의도점",
@@ -45,6 +60,11 @@ const placesInfo = [
     rating: "4.2",
     reviewCount: 870,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
   {
     place: "이디야 커피 신촌점",
@@ -52,6 +72,11 @@ const placesInfo = [
     rating: "4.0",
     reviewCount: 300,
     images: ["/png/food.png"],
+    info: [
+      { label: "영업시간", value: "11:00 - 21:00" },
+      { label: "브레이크 타임", value: "15:00 - 17:00" },
+      { label: "메모", value: "새우튀김을 꼭 시켜야 함" },
+    ],
   },
 ];
 

--- a/app/vote-finish/page.tsx
+++ b/app/vote-finish/page.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { ColumnsType } from "../edit-course/_components/DragAndDropArea";
+import ResultArea from "./_components/ResultArea";
+
+const initialColumns: ColumnsType = {
+  course: {
+    id: "course",
+    list: {
+      food: [{ globalIndex: 0, title: "음식점", type: "food", icon: "🍔" }],
+      dessert: [{ globalIndex: 1, title: "카페", type: "dessert", icon: "🥨" }],
+      beer: [
+        { globalIndex: 2, title: "술 1차", type: "dessert", icon: "🥨" },
+        { globalIndex: 3, title: "술 2차", type: "dessert", icon: "🥨" },
+      ],
+      play: [{ globalIndex: 4, title: "놀거리", type: "play", icon: "🥨" }],
+    },
+  },
+};
+
+const placesInfo = [
+  {
+    place: "옥소반 상암점",
+    link: "abcd",
+    rating: "4.01",
+    reviewCount: 433,
+    images: ["/png/food.png"],
+  },
+  {
+    place: "스타벅스 강남점",
+    link: "efgh",
+    rating: "4.5",
+    reviewCount: 1200,
+    images: ["/png/food.png"],
+  },
+  {
+    place: "맥도날드 홍대점",
+    link: "ijkl",
+    rating: "3.8",
+    reviewCount: 530,
+    images: ["/png/food.png"],
+  },
+  {
+    place: "빕스 여의도점",
+    link: "mnop",
+    rating: "4.2",
+    reviewCount: 870,
+    images: ["/png/food.png"],
+  },
+  {
+    place: "이디야 커피 신촌점",
+    link: "qrst",
+    rating: "4.0",
+    reviewCount: 300,
+    images: ["/png/food.png"],
+  },
+];
+
+const VoteEditPage = () => {
+  return (
+    <div>
+      <ResultArea initialColumns={initialColumns} placesInfo={placesInfo} />
+    </div>
+  );
+};
+
+export default VoteEditPage;

--- a/components/common/Cards/CardsWithResult.tsx
+++ b/components/common/Cards/CardsWithResult.tsx
@@ -1,0 +1,96 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { CardInfoProps } from "@/model";
+import Image from "next/image";
+
+export const CardWithSelectedOption: React.FC<CardInfoProps> = ({
+  place,
+  rating,
+  reviewCount,
+  images,
+  onButtonClick,
+  selected,
+}) => {
+  return (
+    <Card
+      className={`flex flex-col w-[335px] h-[104px] items-start justify-center cursor-pointer p-[12px] rounded-[16px] group-active:border-2 group-active:border-[#FF601C]`}
+    >
+      <CardContent className="flex flex-col w-[295px] h-[80px]">
+        <div className="flex flex-row w-full h-full">
+          <Image
+            src={images[0]}
+            alt="food"
+            className="rounded-lg"
+            width={80}
+            height={80}
+            priority
+          />
+          <div className="flex flex-row pl-[12px] items-center justify-center gap-y-[4px]">
+            <div className="flex flex-col max-w-[183px] h-[24px] items-start justify-center pr-[9px]">
+              <div className="flex flex-row max-w-full items-center gap-x-[8px]">
+                <span className="flex flex-row w-full max-w-[134px] whitespace-nowrap overflow-hidden text-ellipsis h-[21px] text-[16px] text-black font-semibold items-center">
+                  {place}
+                </span>
+                <Badge className="flex w-[25px] h-[21px] px-[5px] py-[3px] border-none text-[10px] rounded-[6px] bg-[#F4EFFF]">
+                  <span className="w-[15px] h-[15px] text-[#622DBC] font-semibold">
+                    6명
+                  </span>
+                </Badge>
+              </div>
+              <div className="flex flex-row w-[183px] h-[24px] gap-x-[2px] items-center">
+                <Image
+                  src="/png/naver.png"
+                  alt="naver"
+                  width={12}
+                  height={12}
+                  className="items-center"
+                  priority
+                />
+                <span className="text-[14px] max-w-[24px] h-[18px] text-black flex items-center">
+                  {rating}
+                </span>
+                <span className="text-[14px] min-w-[36px] h-[18px] items-center flex text-[#B5B9C6]">
+                  ({reviewCount})
+                </span>
+              </div>
+
+              <div className="flex flex-row w-[183px] h-[79px] py-[4px] pr-[8px] mt-[8px] gap-x-[2px]">
+                <span className="w-[46px] h-[15px] text-[10px] text-[#747B89]">
+                  자세히 보기
+                </span>
+                <Image
+                  src={"svg/ic_arrow_right.svg"}
+                  alt="arrow"
+                  width={10}
+                  height={10}
+                  priority
+                  unoptimized
+                />
+              </div>
+            </div>
+            <button
+              className={`flex w-[24px] h-[24px] items-center justify-center rounded-2xl  ${
+                selected
+                  ? "border-none"
+                  : "border-2 border-[#E7E8EB] hover:border-[#FFD6D9]"
+              }  mr-[8px]`}
+              onClick={onButtonClick}
+            >
+              {selected && (
+                <Image
+                  src={"png/ic_check_circle-1_24.png"}
+                  alt="check"
+                  className=""
+                  width={24}
+                  height={24}
+                  priority
+                  unoptimized
+                />
+              )}
+            </button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/model/index.ts
+++ b/model/index.ts
@@ -1,4 +1,7 @@
-import { OrderType } from "@/app/edit-course/_components/DragAndDropArea";
+import {
+  ColumnsType,
+  OrderType,
+} from "@/app/edit-course/_components/DragAndDropArea";
 
 export enum Size {
   small = "small",
@@ -40,4 +43,9 @@ export interface CardIconProps {
 export interface PendingCardListProps {
   cards: { place: string; images: string[] }[];
   type: OrderType;
+}
+
+export interface VoteAreaProps {
+  initialColumns: ColumnsType;
+  placesInfo: CardInfoProps[];
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/778afde3-1464-403f-a987-130e5b504f27

feature/#53 PR과 함께, 컴포넌트 구성과 영역 관련 작업을 완료했습니다. @yungjurick 
이번 PR에서는 투표 종료 이후 최종 결과를 CardWithImage component와 toggle효과로 보여주는 화면을 구현했습니다.

해당 PR이 머지되면 **투표 진행 중에 결과를 확인하는 화면 & 투표 진행 후 최종 결과를 보여주는 화면에서 활용**하시면 됩니다 !
리뷰 요청드립니다 :ㅇ


현재 mock data를 지역적으로 각 파일에 선언해둔 상태임을 참고 부탁드립니다.
(이미지는 최대 3장이며 해당 영상에서는 mock data 기준 각 카드 컴포넌트가 하나의 이미지만을 가지고 있습니다.)
- 기존 CardInfoProps를 활용한 인터페이스 재정의
- includes 메서드를 활용해 각 CardWithImage 컴포넌트에 대한 토글 여부를 관리
