### PR TITLE
fix: Set scheduleId as nullable value with edit page

### DIFF
--- a/apis/schedule/types/dto/index.ts
+++ b/apis/schedule/types/dto/index.ts
@@ -1,11 +1,11 @@
 export type RegisterScheduleRequest = {
-  scheduleId?: number;
+  scheduleId?: number | null;
   name: string;
   type: string; // ARCADE, DISH, DESSERT, ALCOHOL
   sequence: number;
 };
 
 export type RegisterSchedulesRequest = {
-  roomUid:string;
+  roomUid: string;
   schedules: RegisterScheduleRequest[];
 };

--- a/apis/schedule/types/model/index.ts
+++ b/apis/schedule/types/model/index.ts
@@ -4,7 +4,7 @@ export type ResponseForm = {
 };
 
 export type ScheduleResponse = {
-  scheduleId: number;
+  scheduleId?: number | null;
   name: string;
   sequence: number;
   type: "ARCADE" | "DISH" | "DESSERT" | "ALCOHOL";

--- a/app/add-course/_components/AddCourse.tsx
+++ b/app/add-course/_components/AddCourse.tsx
@@ -233,8 +233,7 @@ const AddCourse = ({ data }: AddCourseProps) => {
               name={autoData.data.name}
               url={autoData.data.url}
               placeImageUrls={autoData.data.placeImageUrls}
-              // starGrade={autoData.data.starGrade} starGrade가 response에 없음
-              starGrade={4.45}
+              starGrade={autoData.data.starGrade}
               reviewCount={autoData.data.reviewCount}
               origin={autoData.data.origin}
             />
@@ -280,13 +279,14 @@ const AddCourse = ({ data }: AddCourseProps) => {
         >
           {categoryList?.map(
             (item) =>
-              item.scheduleId &&
+              item.scheduleId !== null &&
+              item.scheduleId !== undefined &&
               item.name && (
                 <CategoryChip
                   key={item.scheduleId}
                   title={item.name}
                   selected={selectedChip === item.scheduleId}
-                  onClick={() => handleChipClick(item.scheduleId)}
+                  onClick={() => handleChipClick(item.scheduleId as number)}
                 />
               )
           )}
@@ -354,7 +354,8 @@ const AddCourse = ({ data }: AddCourseProps) => {
         categoryList && (
           <PlaceContainer
             placesData={{
-              scheduleId: selectedCategory ?? categoryList[0]?.scheduleId,
+              scheduleId:
+                selectedCategory ?? (categoryList[0]?.scheduleId as number),
               scheduleName:
                 categoryList?.find(
                   (category) => category.scheduleId === selectedCategory

--- a/app/add-course/detail/_components/PlaceDetail.tsx
+++ b/app/add-course/detail/_components/PlaceDetail.tsx
@@ -55,7 +55,7 @@ const PlaceDetail: React.FC = () => {
     }
 
     const payload: AddPlaceRequestDto = {
-      scheduleId: selectedCategory.scheduleId,
+      scheduleId: selectedCategory.scheduleId as number,
       type: selectedCategory.name,
       name:
         autoPlaceInfo && autoPlaceInfo[0] ? autoPlaceInfo[0].name : placeName,
@@ -139,13 +139,14 @@ const PlaceDetail: React.FC = () => {
           <div className="flex flex-row w-[252px] h-[98px] gap-x-[8px]">
             {categoryList?.map(
               (item) =>
-                item.scheduleId &&
+                item.scheduleId !== null &&
+                item.scheduleId !== undefined &&
                 item.name && (
                   <CategoryChip
                     key={item.scheduleId}
                     title={item.name}
                     selected={selectedChip === item.scheduleId}
-                    onClick={() => handleChipClick(item.scheduleId)}
+                    onClick={() => handleChipClick(item.scheduleId as number)}
                   />
                 )
             )}

--- a/app/edit-course/_components/DragAndDropArea.tsx
+++ b/app/edit-course/_components/DragAndDropArea.tsx
@@ -225,10 +225,9 @@ const DragAndDropArea: React.FC = () => {
 
   const handleItemClick = (type: OrderType2) => {
     const label = findLabelForType(type);
-    const lastItem = columns[columns.length - 1];
-    const newScheduleId = lastItem.scheduleId + 1;
+
     const newItem: ScheduleResponse = {
-      scheduleId: newScheduleId,
+      scheduleId: null,
       type,
       name: `${label} ${columns.length + 1}차`,
       sequence: columns.length + 1,


### PR DESCRIPTION
장소 카테고리 수정 페이지에서 새로운 스케줄을 등록할 경우 scheduleId column을 **nullable**하게 수정합니다.