### PR TITLE
fix: Modifying card ui according to property value range

### DIFF
--- a/components/common/Cards/CardForCopiedContent.tsx
+++ b/components/common/Cards/CardForCopiedContent.tsx
@@ -72,12 +72,12 @@ export const CardForCopiedContent: React.FC<CardForCopiedContentProps> = ({
                     unoptimized
                   />
                 </div>
-                {starGrade && (
+                {starGrade !== 0 && (
                   <span className="w-[24px] h-[18px] text-[12px] text-[#363A3C] font-semibold">
                     {formattedStarGrade}
                   </span>
                 )}
-                {reviewCount && (
+                {reviewCount !== 0 && (
                   <span className="w-[31px] h-[18px] text-[12px] text-[#363A3C] opacity-50">
                     ({reviewCount})
                   </span>

--- a/components/common/Cards/CardWithAutoCompleteData.tsx
+++ b/components/common/Cards/CardWithAutoCompleteData.tsx
@@ -33,11 +33,11 @@ export const CardWithAutoCompleteData = ({
                 </div>
               )}
               <div className="flex w-full whitespace-nowrap gap-x-[8px] items-center h-[31px] text-semibold-22">
-                <div className="flex w-full text-overflow-ellipsis whitespace-nowrap items-center">
+                <div className="w-full max-w-[235px] inline-block whitespace-nowrap overflow-hidden text-ellipsis items-center">
                   {autoData?.data.name}
                 </div>
 
-                <div className="flex w-full gap-x-[4px] items-center">
+                <div className="flex w-full  max-w-[100px]  gap-x-[4px] items-center">
                   <div className="flex w-[16px] h-[16px]">
                     <Image
                       src="/svg/naver-icon.svg"
@@ -48,8 +48,13 @@ export const CardWithAutoCompleteData = ({
                       unoptimized
                     />
                   </div>
-                  <div className="w-full text-[14px]">
-                    {formattedStarGrade} ({autoData?.data?.reviewCount})
+                  <div className="flex flex-row items-center gap-x-[8px] w-full text-[14px]">
+                    {autoData?.data?.starGrade !== 0 && (
+                      <p>{formattedStarGrade}</p>
+                    )}
+                    {autoData?.data?.reviewCount !== 0 && (
+                      <p>({autoData?.data?.reviewCount})</p>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
- 복사한 링크를 추가한 경우 사용하는 CardForCopiedContent
- 자동완성된 장소 정보를 보여주는 CardWithAutoCompleteData
컴포넌트에 대한 UI를 수정합니다. 

1. 별점/리뷰 수가 0인 경우에 대한 hidden 처리
2. 장소 정보 이름이 길어질 경우 말줄임 + max-w 값 추가적으로 부여