### PR TITLE
fix: Fix onClick() event with window.open() resolve #150

### DIFF
--- a/components/common/Cards/CardWithAutoCompleteData.tsx
+++ b/components/common/Cards/CardWithAutoCompleteData.tsx
@@ -85,7 +85,7 @@ export const CardWithAutoCompleteData = ({
       {placeUrl && (
         <button
           className="flex flex-row items-center justify-center w-full h-[42px] bg-[#F9FAFB] py-[12px] px-[111px] rounded-2xl gap-x-[4px]"
-          onClick={() => router.push(placeUrl)}
+          onClick={() => window.open(placeUrl)}
         >
           <div className="w-full h-[18px] opacity-80 text-[12px] font-semibold">
             링크 바로가기


### PR DESCRIPTION
- 자동 입력을 통해 추가되는 장소의 상세 페이지에서, 링크 바로가기 버튼을 클릭했을 때 해당 장소의 링크가 새 탭에서 열릴 수 있도록 변경합니다.