### PR TITLE
fix: Fix the logic with empty scheduleIds resolve #152

### DIFF
--- a/app/add-course/detail/_components/AddPlaceDetail.tsx
+++ b/app/add-course/detail/_components/AddPlaceDetail.tsx
@@ -18,6 +18,7 @@ import { FormProvider } from "react-hook-form";
 import { useCreatePlace } from "@/apis/place/PlaceApi.mutation";
 import { PlaceAutoCompleteResponse } from "@/apis/origin-place/types/dto";
 import { createFileFromImagePath } from "@/lib/utils";
+import scheduleApi from "@/apis/schedule/ScheduleApi";
 
 export type DefaultImageType = {
   id: string;
@@ -163,7 +164,7 @@ const AddPlaceDetail: React.FC = () => {
       scheduleIds
     );
 
-    if (!values.name || !selectedChips || !selectedCategory) {
+    if (!values.name || scheduleIds.length === 0) {
       return;
     }
 

--- a/app/add-course/detail/_components/EditPlaceDetail.tsx
+++ b/app/add-course/detail/_components/EditPlaceDetail.tsx
@@ -111,7 +111,7 @@ const EditPlaceDetail: React.FC = () => {
 
   const onCompleteButtonClick = async () => {
     const values = methods.getValues();
-    if (!values.name || !selectedChip || !selectedPlaceInfo) {
+    if (!values.name || selectedChip === null || !selectedPlaceInfo) {
       return;
     }
 


### PR DESCRIPTION
- 장소 추가/수정 flow에서, 카테고리가 선택되지 않은 경우의 예외 처리 로직을 수정합니다.