### PR TITLE
fix: Add latitude/longitude options to payload resolve #204

### DIFF
--- a/apis/origin-place/types/dto/index.ts
+++ b/apis/origin-place/types/dto/index.ts
@@ -12,6 +12,8 @@ export type PlaceAutoCompleteResponse = {
     reviewCount?: number;
     category?: string;
     origin: "AVOCADO" | "LEMON" | "MANUAL";
+    longitude?: number | null;
+    latitude?: number | null;
   };
   timestamp: number;
 };

--- a/app/add-course/detail/_components/AddPlaceDetail.tsx
+++ b/app/add-course/detail/_components/AddPlaceDetail.tsx
@@ -75,8 +75,8 @@ const getPayloadForRequest = (
     memo: values.memo || "-",
     origin: autoData?.data?.origin || "MANUAL",
     voteLikeCount: 0,
-    longitude: 0,
-    latitude: 0,
+    longitude: autoData ? autoData?.data?.longitude : null,
+    latitude: autoData ? autoData?.data?.latitude : null,
     autoCompletedPlaceImageUrls:
       autoData?.data?.placeImageUrls?.contents[0] === "null"
         ? [defaultAutoImage]


### PR DESCRIPTION
- 장소 자동 추가 시, payload의 위/경도 옵션을 nullable하게 수정합니다.